### PR TITLE
Add level_name in extra data

### DIFF
--- a/src/Processor/LaravelProcessor.php
+++ b/src/Processor/LaravelProcessor.php
@@ -31,6 +31,7 @@ class LaravelProcessor
     {
         $record['extra']['app'] = $this->config->get('log.app');
         $record['extra']['env'] = $this->app->environment();
+        $record['extra']['level_name'] = $record['level_name'];
 
         return $record;
     }


### PR DESCRIPTION
Add `level_name` to record extra data. Numeric value `level` is already sent, but not very user friendly.