### PR TITLE
Add support for Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     "require": {
         "php": "^7.1",
         "graylog2/gelf-php": "^1.5",
-        "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*",
-        "illuminate/log": "5.5.*|5.6.*|5.7.*|5.8.*",
-        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*"
+        "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
+        "illuminate/log": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*",
+        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
# Description

This PR add support for Laravel 6.0 released on Septembre 6th, 2019.